### PR TITLE
fix: add missing react-native-worklets dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0",
+    "react-native-worklets": "^0.5.1",
     "zustand": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
Jest tests fail with 'Cannot find module react-native-worklets/plugin' because the required peer dependency is missing from package.json.

## Solution
- Added `react-native-worklets@^0.5.1` to dependencies
- Required peer dependency for `react-native-reanimated@~4.1.0`
- Fixes Babel plugin loading in Jest test environment

## Verification
- All 51 tests now pass successfully
- No breaking changes to existing functionality
- Resolves CI failures in downstream integration repository

## Impact
- Unblocks frontend unit tests in CI/CD pipelines
- Enables proper React Native Reanimated worklets functionality
- Maintains compatibility with Expo SDK 54