### PR TITLE
feat: implement image picker for edit profile

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -262,7 +262,7 @@ export default function HomeScreen() {
               <TouchableOpacity 
                 key={bff.id} 
                 style={styles.bffCard}
-                onPress={() => router.push(`/bffProfileDetail/${bff.id}`)}
+                onPress={() => router.push(`/profile/${bff.id}`)}
                 accessibilityLabel={`View ${bff.name}'s profile, ${bff.age} years old`}
                 accessibilityRole="button"
               >

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -269,12 +269,6 @@ function RootNavigation() {
             })}
           />
           <Stack.Screen
-            name="bffProfileDetail/[userId]"
-            options={{
-              headerShown: false,
-            }}
-          />
-          <Stack.Screen
             name="profile/[userId]"
             options={{
               headerShown: false,
@@ -454,7 +448,6 @@ function RootNavigation() {
           {/* <Stack.Screen name="exploreGroups" /> */}
           {/* <Stack.Screen name="locationDetail/[locationName]" /> */}
           {/* <Stack.Screen name="popularGroupDetail/[groupId]" /> */}
-          {/* <Stack.Screen name="bffProfileDetail/[userId]" /> */}
           {/* <Stack.Screen name="conversation/[chatId]" /> */}
           {/* <Stack.Screen name="createGroup" /> */}
           {/* <Stack.Screen name="planNightOutPlaceholder" /> */}

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -63,7 +63,6 @@ export type RootStackParamList = {
   // --- Phase 5a Navigation Targets ---
   locationDetail: { locationName: string; };
   exploreGroups: undefined;
-  bffProfileDetail: { userId: string; };
   // nearbyGroupsList: undefined; // Using exploreGroups route for now
   createGroup: undefined; // Target for Create Group button
   planNightOutPlaceholder: undefined;


### PR DESCRIPTION
- Implements image selection functionality for all three profile picture slots on the Edit Profile screen using expo-image-picker.
- Includes permission handling and user feedback for denied permissions.
- Fixes deprecated use of 'MediaTypeOptions' to the modern 'images' string literal.
- Also includes a fix for a dead navigation link that was pointing to a deleted 'bffProfileDetail' route, updating it to the correct '/profile' route.